### PR TITLE
bug fix: overflow none on hero carousel parent to prevent framer motion from tracking absolut…

### DIFF
--- a/features/hero/hero.tsx
+++ b/features/hero/hero.tsx
@@ -25,7 +25,7 @@ const Hero = () => {
   return (
     <main className="relative w-full mt-20" id="hero">
       <SiteBG />
-      <div className="w-full max-w-6xl flex flex-col justify-start items-center gap-16 mx-auto px-6 mb-6">
+      <div className="w-full max-w-6xl flex flex-col justify-start items-center gap-16 mx-auto px-6 mb-6 overflow-hidden">
         <Pitch
           mobile={mobile}
           isFirstRender={isFirstRender}

--- a/features/heroCarousel/HeroCarousel.tsx
+++ b/features/heroCarousel/HeroCarousel.tsx
@@ -175,7 +175,7 @@ const PositionedImage = (props: PositionedImageProps) => {
         priority
         src={src}
         alt={alt}
-        className={`z-0 w-full aspect-[5/3] max-h-full object-${objectFit} rounded-sm border-[1px] border-[white]`}
+        className={`z-0 w-full aspect-[5/3] max-h-full object-${objectFit} rounded-md border-[1px] border-[hsla(0,0%,80%,80%)]`}
       />
       <BlurredFrame />
     </motion.div>


### PR DESCRIPTION
bug fix: overflow none on hero carousel parent to prevent framer motion from tracking absolutely positioned images rendered visually outside div during exit animation. painful bug.